### PR TITLE
[Enhancement] Mob Types

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,12 +1,9 @@
 ---
 name: PEXProtection
 author: RevivalPMMP
-api:
-- 3.0.0-ALPHA7
-- 3.0.0-ALPHA8
-- 3.0.0-ALPHA9
+api: [3.0.0-ALPHA9]
 main: RevivalPMMP\PEXProtection\Main
-version: 0.1.0
+version: 0.1.1
 
 commands:
     pexprotection:

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -1,0 +1,7 @@
+---
+# World where entities will not be allowed to spawn automatically.
+Disabled-Worlds: []
+
+# Setting All-Mobs to true will prevent all entitys from spawning in protected areas.
+All-Mobs: true;
+...

--- a/src/RevivalPMMP/PEXProtection/Main.php
+++ b/src/RevivalPMMP/PEXProtection/Main.php
@@ -2,12 +2,12 @@
 
 namespace RevivalPMMP\PEXProtection;
 
+use pocketmine\block\Block;
 use pocketmine\plugin\PluginBase;
 use pocketmine\utils\TextFormat as TF;
 use pocketmine\utils\Config;
 use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
-use pocketmine\utils\TextFormat;
 use revivalpmmp\pureentities\event\CreatureSpawnEvent;
 use pocketmine\event\Listener;
 use pocketmine\event\player\PlayerInteractEvent;
@@ -16,179 +16,164 @@ use pocketmine\Player;
 
 class Main extends PluginBase implements Listener {
 
-	/** @var Config */
-	public $centers;
-	/** @var array */
-	private $tapping = [];
-	/** @var string */
-	private $blockName = "";
-	/** @var int */
-	private $radius = 0;
-	
-	public function onEnable(): void {
-		$this->getServer()->getPluginManager()->registerEvents($this, $this);
-		@mkdir($this->getDataFolder());
-		$this->centers = new Config($this->getDataFolder() . "centers.yml", Config::YAML, [
-			"Disabled-Worlds" => []
-		]);
-	}
+    /**
+     * @var Config
+     */
+    public $centers;
+	private $tapping;
+	private $level;
+    private $blockName;
+    private $radius;
+    private $allMobs;
 
-	/**
-	* @param string $blockName
-	*
-	* @return bool
-	*/
-	public function isCenterBlock(string $blockName): bool {
-		return $this->centers->exists($blockName);
-	}
+    public function onEnable() {
+        $this->getServer()->getPluginManager()->registerEvents($this, $this);
+        $this->saveDefaultConfig();
+        $this->centers = new Config($this->getDataFolder() . "centers.yml", Config::YAML);
+        $this->getServer()->getLogger()->info(TF::GREEN . "PEXProtector Enabled!");
+    }
+    
+    public function isCenterBlock(string $blockName) {
+        return $this->centers->exists($blockName);
+    }
+    
+    public function isCenterBlockLocation(Block $location) {
+        foreach($this->centers->getAll() as $center) {
+            if($center["xPos"] === $location->x
+                && $center["yPos"] === $location->y
+                && $center["zPos"] === $location->z
+                && $location->getLevel()->getName() === $center["level"]) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    public function setCenterBlock(string $blockName, Block $location, int $radius, string $level, bool $allMobs) {
+        $this->centers->set($blockName, array(
+            "xPos" => $location->getX(),
+            "yPos" => $location->getY(),
+            "zPos" => $location->getZ(),
+            "level" => $level,
+            "radius" => $radius,
+            "allmobs" => $allMobs
+        ));
+        $this->centers->save();
+    }
+    
+    public function inTapMode(Player $p): bool {
+        if(isset($this->tapping[$p->getName()])) {
+            return true;
+        }
+        return false;
+    }
+    
+    public function onCreatureSpawn(CreatureSpawnEvent $event) {
+    	if(in_array($event->getLevel()->getName(), $this->getConfig()->get("Disabled-Worlds"))) {
+		    $event->setCancelled();
+	    }
+	    foreach($this->centers->getAll() as $areaCenter => $centerInfo){
+            $pos = new Position(
+                $centerInfo["xPos"],
+                $centerInfo["yPos"],
+                $centerInfo["zPos"],
+                $this->getServer()->getLevelByName($centerInfo["level"])
+            );
+            $entity = $event->getPosition();
+            if(($entity->distance($pos) < $centerInfo["radius"] && $centerInfo["level"] === $event->getLevel()->getName()) || in_array($event->getLevel()->getName(), $this->getConfig()->get("Disabled-Worlds"))) {
+                if(strcmp(strtolower($event->getType()), "monster") == 0 || $centerInfo["allmobs"]) {
+                    $event->setCancelled();
+                }
+            }
+	    }
+    }
+    
+    public function onCommand(CommandSender $p, Command $cmd, string $label, array $args) : bool {
+        if($cmd->getName() === "pexprotection") {
+            if($p->hasPermission("pexprotection.command") && $p instanceof Player) {
+                if(isset($args[1])) {
 
-	/**
-	* @param Position $position
-	*
-	* @return bool
-	*/
-	public function isCenterBlockLocation(Position $position): bool {
-		foreach($this->centers->getAll() as $center) {
-			if(!$center === $this->centers->get("Disabled-Worlds")) {
-				if($center["x"] === $position->x && $center["y"] === $position->y && $center["z"] === $position->z && $position->getLevel()->getName() === $center["level"]) {
-					return true;
-				}
-			}
-		}
-		return false;
-	}
-
-	/**
-	* @param string   $blockName
-	* @param Position $position
-	* @param int      $radius
-	*/
-	public function setCenterBlock(string $blockName, Position $position, int $radius): void {
-		$this->centers->set($blockName, [
-			"x" => $position->getX(),
-			"y" => $position->getY(),
-			"z" => $position->getZ(),
-			"level" => $position->level->getName(),
-			"radius" => $radius
-		]);
-		$this->centers->save();
-	}
-
-	/**
-	* @param Player $player
-	*
-	* @return bool
-	*/
-	public function inTapMode(Player $player): bool {
-		return isset($this->tapping[$player->getName()]);
-	}
-
-	/**
-	* @param CreatureSpawnEvent $event
-	*/
-	public function onCreatureSpawn(CreatureSpawnEvent $event): void {
-		if(in_array($event->getLevel()->getName(), $this->centers->get("Disabled-Worlds"))) {
-			$event->setCancelled();
-		}
-		foreach($this->centers->getAll() as $center){
-			if(!$center === $this->centers->get("Disabled-Worlds")) {
-				$pos = new Position(
-					$center["x"],
-					$center["y"],
-					$center["z"],
-					$this->getServer()->getLevelByName($center["level"])
-				);
-				$entity = $event->getPosition();
-				if(($entity->distance($pos) < $center["radius"] && $center["level"] === $event->getLevel()->getName()) || in_array($event->getLevel()->getName(), $this->centers->get("Disabled-Worlds"))) {
-					$event->setCancelled();
-				}
-			}
-		}
-	}
-
-	/**
-	* @param CommandSender $sender
-	* @param Command       $command
-	* @param string        $commandLabel
-	* @param array         $args
-	*
-	* @return bool
-	*/
-	public function onCommand(CommandSender $sender, Command $command, string $commandLabel, array $args): bool {
-		if($sender->hasPermission("pexprotection.command")) {
-			if(isset($args[1])) {
-
-				switch($args[0]) {
-					case "add":
-					case "set":
-					case "create":
-					case "make":
-						if(!($sender instanceof Player)) {
-							$sender->sendMessage(TextFormat::RED . "You cannot execute this command using console.");
-							return true;
-						}
-						if(!$this->isCenterBlock($args[1])) {
-							if(isset($args[2])) {
-								$sender->sendMessage(TF::AQUA . "Tap a block to add a protection center block with the name " . $args[1] . "!");
-								$this->tapping[$sender->getName()] = $sender->getName();
-								$this->blockName = $args[1];
-								$this->radius = (int) $args[2];
-							} else {
-								$sender->sendMessage(TF::RED . "You have to define a radius for the protection center block!");
-							}
-						} else {
-							$sender->sendMessage(TF::RED . "A protection center block with that name already exists");
-						}
-						return true;
-
-					case "disableworld":
-					case "world":
-						$sender->sendMessage(TF::GREEN . "Successfully added a world to disable monster spawning.");
-						$worlds = $this->centers->get("Disabled-Worlds");
-						$worlds[] = $args[1];
-						$this->centers->set("Disabled-Worlds", $worlds);
-						$this->centers->save();
-						return true;
-
-					case "delete":
-					case "del":
-					case "remove":
-					case "rem":
-					case "clear":
-						if($this->isCenterBlock($args[1])) {
-							$sender->sendMessage(TF::AQUA . "Successfully removed the protection center block " . $args[1] . "!");
-							$this->centers->remove($args[1]);
-							$this->centers->save();
-						} else {
-							$sender->sendMessage(TF::RED . "That protection center block name does not exist.");
-						}
-						return true;
-				}
-			} else {
-				$sender->sendMessage(TF::RED . "Please provide a valid protection center block name!");
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
-	* @param PlayerInteractEvent $ev
-	*/
-	public function onInteract(PlayerInteractEvent $ev): void {
-		$player = $ev->getPlayer();
-		if($this->inTapMode($player)) {
-			if(!$this->isCenterBlockLocation($ev->getBlock())) {
-				$player->sendMessage(TF::GREEN . "Successfully added a protection center block with radius" . $this->radius . "!");
-				unset($this->tapping[$player->getName()]);
-
-				$this->setCenterBlock($this->blockName, $ev->getBlock(), $this->radius);
-				$this->blockName = "";
-				$this->radius = 0;
-				$ev->setCancelled();
-			} else {
-				$player->sendMessage(TF::RED . "A protection center block at that location already exists!");
-			}
-		}
-	}
+                    switch($args[0]) {
+                        case "add":
+                        case "set":
+                        case "create":
+                        case "make":
+                            if(!$this->isCenterBlock($args[1])) {
+                                if(isset($args[2])) {
+                                    $p->sendMessage(TF::AQUA . "Tap a block to add a protection center block with the name " . $args[1] . "!");
+                                    $this->tapping = array();
+                                    $this->tapping[$p->getName()] = $p->getName();
+                                    $this->level = $p->getLevel()->getName();
+                                    $this->blockName = $args[1];
+                                    $this->radius = $args[2];
+                                    if(isset($args[3])) {
+                                        $this->allMobs = (strcmp(strtolower($args[3]), "true") == 0) ? true : false;
+                                    } else {
+                                        if ($this->getConfig()->exists("All-Mobs")) {
+                                            $this->allMobs = $this->getConfig()->get("All-Mobs");
+                                        } else {
+                                            $this->allMobs = true;
+                                        }
+                                    }
+                                } else {
+                                    $p->sendMessage(TF::RED .  "You have to define a radius for the protection center block!");
+                                }
+                            } else {
+                                $p->sendMessage(TF::RED . "A protection center block with that name already exists");
+                            }
+                            return true;
+                        
+	                    case "disableworld":
+	                    case "world":
+	                    	if(isset($args[1])) {
+			                    $worlds = $this->getConfig()->get("Disabled-Worlds");
+			                    $worlds[] = $args[1];
+			                    $this->getConfig()->set("Disabled-Worlds", $worlds);
+			                    $this->saveDefaultConfig();
+                                $p->sendMessage(TF::GREEN . "Successfully added a world to disable monster spawning.");
+		                    }
+		                    return true;
+	                    
+                        case "delete":
+                        case "del":
+                        case "remove":
+                        case "rem":
+                        case "clear":
+                            if($this->isCenterBlock($args[1])) {
+                                $this->centers->remove($args[1]);
+                                $this->centers->save();
+                                $p->sendMessage(TF::AQUA . "Successfully removed the protection center block " . $args[1] . "!");
+                            } else {
+                                $p->sendMessage(TF::RED . "That protection center block name does not exist.");
+                            }
+                            return true;
+                    }
+                } else {
+                    $p->sendMessage(TF::RED . "Please provide a valid protection center block name!");
+                }
+            } else {
+                $this->getServer()->getLogger()->info(TF::RED . "PEXProtector commands must be used by players.");
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    public function onInteract(PlayerInteractEvent $ev) {
+        $p = $ev->getPlayer();
+        if($this->inTapMode($p)) {
+            if(!$this->isCenterBlockLocation($ev->getBlock())) {
+                unset($this->tapping[$p->getName()]);
+                $this->setCenterBlock($this->blockName, $ev->getBlock(), $this->radius, $this->level, $this->allMobs);
+                $p->sendMessage(TF::GREEN . "Successfully added a protection center block with radius " . $this->radius . "!");
+                unset($this->blockName);
+                unset($this->radius);
+                unset($this->level);
+                unset($this->allMobs);
+                $ev->setCancelled();
+            } else {
+                $p->sendMessage(TF::RED . "A protection center block at that location already exists!");
+            }
+        }
+    }
 }


### PR DESCRIPTION
This adds new functionality to the plugin making it possible for users to choose whether to block only monsters or all mobs.

This also address an issue when creating centers.yml where the "y" key of a center block would be stored with the quotes causing the plugin to fail in protecting areas.